### PR TITLE
chore(ci): bump node version to 14.x

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js 12.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v2
       with:
-        node-version: 12.x
+        node-version: 14.x
     - run: yarn install --frozen-lockfile
     - run: yarn build
     - run: yarn test


### PR DESCRIPTION
### What does this PR do?

Bump Node.js version to v14.x during CI runs.
